### PR TITLE
Add missing 'TRACE_GROUP' definition to capsense.cpp

### DIFF
--- a/capsense.cpp
+++ b/capsense.cpp
@@ -20,8 +20,10 @@
 #include "capsense.h"
 #include "mbed_power_mgmt.h"
 #include "mbed_trace.h"
+
 using namespace std::literals::chrono_literals;
 
+#define TRACE_GROUP "CAP"
 #define SLIDER_NUM_TOUCH (1u)
 #define LED_OFF (1u)
 #define LED_ON (0u)


### PR DESCRIPTION
## Problem
When `mbed_traces` are enabled, the mbed-os-cypress-capsense-button module generates compilation error due to missing `TRACE_GROUP` definition in capsense.cpp.

## Change set
Add missing `TRACE_GROUP` definition. 