### PR TITLE
Cmake file improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,23 @@
 # Copyright (c) 2021 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-set(CAPSENSE_SOURCES
+add_library(capsense INTERFACE)
+
+if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+    set(CY_CAPSESNE_LIB COMPONENT_SOFTFP/TOOLCHAIN_GCC_ARM/libcy_capsense.a)
+elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
+    set(CY_CAPSESNE_LIB COMPONENT_SOFTFP/TOOLCHAIN_ARM/libcy_capsense.ar)
+elseif(${MBED_TOOLCHAIN} STREQUAL "IAR")
+    set(CY_CAPSESNE_LIB COMPONENT_SOFTFP/TOOLCHAIN_IAR/libcy_capsense.a)
+endif()
+
+target_include_directories(capsense
+    INTERFACE
+        .
+)
+
+target_sources(capsense
+    INTERFACE
         capsense.cpp
         cycfg_capsense.c
         cy_capsense_control.c
@@ -17,9 +33,16 @@ set(CAPSENSE_SOURCES
         cy_capsense_sensing_v3.c
         cy_capsense_structure.c
 )
- 
-add_library(capsense STATIC EXCLUDE_FROM_ALL ${CAPSENSE_SOURCES})
- 
-#find_library(CAPSENSE_LIB libcy_capsense ${CHIP_ROOT}/third_party/mbed-os-cypress-capsense-button/repo/COMPONENT_SOFTFP/TOOLCHAIN_GCC_ARM ) #${CMAKE_SOURCE_DIR}/COMPONENT_SOFTFP/TOOLCHAIN_GCC_ARM)
-#target_link_libraries(capsense mbed-core mbed-events mbed-rtos libcy_capsense)
-target_link_libraries(capsense mbed-core mbed-events mbed-rtos)
+
+target_compile_definitions(capsense
+    INTERFACE
+        CAPSENSE_ENABLED=1
+)
+
+target_link_libraries(capsense 
+    INTERFACE
+        mbed-core 
+        mbed-events 
+        mbed-rtos
+        ${CMAKE_CURRENT_SOURCE_DIR}/${CY_CAPSESNE_LIB}
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,11 @@
 add_library(capsense INTERFACE)
 
 if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
-    set(CY_CAPSESNE_LIB COMPONENT_SOFTFP/TOOLCHAIN_GCC_ARM/libcy_capsense.a)
+    set(CY_CAPSENSE_LIB COMPONENT_SOFTFP/TOOLCHAIN_GCC_ARM/libcy_capsense.a)
 elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
-    set(CY_CAPSESNE_LIB COMPONENT_SOFTFP/TOOLCHAIN_ARM/libcy_capsense.ar)
+    set(CY_CAPSENSE_LIB COMPONENT_SOFTFP/TOOLCHAIN_ARM/libcy_capsense.ar)
 elseif(${MBED_TOOLCHAIN} STREQUAL "IAR")
-    set(CY_CAPSESNE_LIB COMPONENT_SOFTFP/TOOLCHAIN_IAR/libcy_capsense.a)
+    set(CY_CAPSENSE_LIB COMPONENT_SOFTFP/TOOLCHAIN_IAR/libcy_capsense.a)
 endif()
 
 target_include_directories(capsense
@@ -44,5 +44,5 @@ target_link_libraries(capsense
         mbed-core 
         mbed-events 
         mbed-rtos
-        ${CMAKE_CURRENT_SOURCE_DIR}/${CY_CAPSESNE_LIB}
+        ${CMAKE_CURRENT_SOURCE_DIR}/${CY_CAPSENSE_LIB}
 )


### PR DESCRIPTION
Create more mbed-os compatible cmake file for this library:
1. Linking Cypress capsense library depends on toolchain type
2. Include base directory
3. Add compilation flag CAPSENSE_ENABLED
Now i the main project you just need use add_subdirectory() and target_link_libraries() cmake command